### PR TITLE
build: Redo CMake files, using normal KDE conventions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,52 @@
+# SPDX-FileCopyrightText: Budgie Desktop Developers
+#
+# SPDX-License-Identifier: MPL-2.0
+
 cmake_minimum_required(VERSION 3.20)
 
-project(bd-v2 VERSION 0.1)
+project(budgie-daemon-v2 VERSION 0.0.1)
 
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_STANDARD 23)
 
+set(KDE_COMPILERSETTINGS_LEVEL 6.0)
+
+set(PROJECT_DEP_VERSION "6.1.80")
+set(QT_MIN_VERSION "6.7")
+set(KF6_MIN_VERSION "6.6.0")
+
+find_package(ECM ${KF6_MIN_VERSION} REQUIRED NO_MODULE)
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${ECM_MODULE_PATH})
+
+include(KDEClangFormat)
+include(KDEGitCommitHooks)
+include(FeatureSummary)
+include(ECMSetupVersion)
+include(KDEInstallDirs)
+include(KDECMakeSettings)
+# include(KDECompilerSettings NO_POLICY_SCOPE)
+include(GenerateExportHeader)
+include(ECMGenerateHeaders)
+
+find_package(Qt6 ${QT_MIN_VERSION} NO_MODULE COMPONENTS Core DBus WaylandClient)
+
+set_package_properties(
+  Qt6 PROPERTIES
+  TYPE REQUIRED
+  PURPOSE "Basic application components")
+
+find_package(Wayland REQUIRED)
+find_package(QtWaylandScanner REQUIRED)
+
+option(INSTALL_SERVICE_FILES "Install service files for autostarting" ON)
+option(INSTALL_LABWC "Install autostart files for labwc" ON)
+
 add_subdirectory(src)
+
+feature_summary(WHAT ALL INCLUDE_QUIET_PACKAGES
+                         FATAL_ON_MISSING_REQUIRED_PACKAGES)
+
+file(GLOB_RECURSE ALL_CLANG_FORMAT_SOURCE_FILES *.cpp *.hpp)
+kde_clang_format(${ALL_CLANG_FORMAT_SOURCE_FILES})
+
+kde_configure_git_pre_commit_hook(CHECKS CLANG_FORMAT)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,54 +1,69 @@
-find_package(Qt6 REQUIRED COMPONENTS Core DBus WaylandClient)
-find_package(ECM REQUIRED NO_MODULE)
-set(CMAKE_MODULE_PATH ${ECM_MODULE_PATH} ${ECM_FIND_MODULE_DIR} ${CMAKE_SOURCE_DIR}/cmake ${CMAKE_BINARY_DIR}/includes)
-
-find_package(Wayland REQUIRED)
-find_package(QtWaylandScanner REQUIRED)
-
-include(KDEInstallDirs)
-include(ECMConfiguredInstall)
-
-qt_standard_project_setup()
-
-set(SRCS
-        displays/configuration.cpp
-        config/display.cpp
-        config/utils.cpp
-        dbus/DisplayAdaptorGen.cpp
-        dbus/DisplayService.cpp
-        displays/output-manager/WaylandOutputManager.cpp
-        main.cpp
-        sys/SysInfo.cpp
-        dbus/DisplaySchemaTypes.hpp
-)
+# SPDX-FileCopyrightText: Budgie Desktop Developers
+#
+# SPDX-License-Identifier: MPL-2.0
 
 add_library(WaylandProtocols_xml OBJECT)
 set_property(TARGET WaylandProtocols_xml PROPERTY POSITION_INDEPENDENT_CODE ON)
-target_link_libraries(WaylandProtocols_xml Qt6::Core Wayland::Client)
+target_link_libraries(WaylandProtocols_xml PUBLIC Qt::Core Wayland::Client)
 set_target_properties(WaylandProtocols_xml PROPERTIES LINKER_LANGUAGE C)
 
-ecm_add_qtwayland_client_protocol(WaylandProtocols_xml
-        PRIVATE_CODE
-        PROTOCOL protocols/wlr-output-management-unstable-v1.xml
-        BASENAME wlr-output-management-unstable-v1
-)
+ecm_add_qtwayland_client_protocol(
+  WaylandProtocols_xml PRIVATE_CODE PROTOCOL
+  protocols/wlr-output-management-unstable-v1.xml BASENAME
+  wlr-output-management-unstable-v1)
 
-add_executable(org.buddiesofbudgie.BudgieDaemonV2 ${SRCS} ${WaylandProtocols_xml})
-target_include_directories(org.buddiesofbudgie.BudgieDaemonV2 PUBLIC ${CMAKE_CURRENT_BINARY_DIR} config dbus displays includes sys)
-target_link_libraries(org.buddiesofbudgie.BudgieDaemonV2 PRIVATE Qt6::Core Qt6::DBus Wayland::Client WaylandProtocols_xml)
-install(
-        FILES dbus/org.buddiesofbudgie.BudgieDaemonX.conf
-        DESTINATION ${CMAKE_INSTALL_DATADIR}/dbus-1/system.d
-)
+add_library(
+  budgie-daemon-v2 STATIC
+  config/display.cpp
+  config/display.hpp
+  config/format.hpp
+  config/utils.cpp
+  config/utils.hpp
+  dbus/DisplayAdaptorGen.cpp
+  dbus/DisplayAdaptorGen.h
+  dbus/DisplaySchemaTypes.hpp
+  dbus/DisplayService.cpp
+  dbus/DisplayService.hpp
+  displays/output-manager/WaylandOutputManager.cpp
+  displays/output-manager/WaylandOutputManager.hpp
+  displays/configuration.cpp
+  displays/configuration.hpp
+  sys/SysInfo.cpp
+  sys/SysInfo.hpp)
 
-install(TARGETS org.buddiesofbudgie.BudgieDaemonV2 DESTINATION ${KDE_INSTALL_TARGETS_DEFAULT_ARGS}/)
-install(
-        FILES data/labwc/autostart
-        DESTINATION /etc/xdg/labwc
-)
+add_executable(budgie-daemon-v2-app main.cpp)
+target_include_directories(
+  budgie-daemon-v2-app PRIVATE ${CMAKE_BINARY_DIR}
+                               ${CMAKE_CURRENT_SOURCE_DIR}/includes)
+target_link_libraries(budgie-daemon-v2-app PRIVATE budgie-daemon-v2)
 
-#ecm_install_configured_files(INPUT data/org.buddiesofbudgie.BudgieDaemonV2.desktop.in DESTINATION ${KDE_INSTALL_AUTOSTARTDIR})
-#ecm_install_configured_files(
-#        INPUT data/org.buddiesofbudgie.BudgieDaemonV2.service.in
-#        DESTINATION ${KDE_INSTALL_SYSTEMDUSERUNITDIR}
-#)
+target_include_directories(
+  budgie-daemon-v2
+  PRIVATE ${CMAKE_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/includes
+          ${CMAKE_CURRENT_SOURCE_DIR}/config ${CMAKE_CURRENT_SOURCE_DIR}/dbus
+          ${CMAKE_CURRENT_SOURCE_DIR}/displays ${CMAKE_CURRENT_SOURCE_DIR}/sys)
+
+target_link_libraries(
+  budgie-daemon-v2 PUBLIC Qt::Core Qt::DBus Qt::WaylandClient Wayland::Client
+                          WaylandProtocols_xml)
+
+set_target_properties(
+  budgie-daemon-v2-app PROPERTIES OUTPUT_NAME
+                                  "org.buddiesofbudgie.BudgieDaemonV2")
+
+install(TARGETS budgie-daemon-v2-app ${KDE_INSTALL_TARGETS_DEFAULT_ARGS})
+install(FILES dbus/org.buddiesofbudgie.BudgieDaemonX.conf
+        DESTINATION ${CMAKE_INSTALL_DATADIR}/dbus-1/system.d)
+
+if(INSTALL_SERVICE_FILES)
+  if(INSTALL_LABWC)
+    install(FILES data/labwc/autostart DESTINATION /etc/xdg/labwc)
+  else()
+    ecm_install_configured_files(
+      INPUT data/org.buddiesofbudgie.BudgieDaemonV2.desktop.in DESTINATION
+      ${KDE_INSTALL_AUTOSTARTDIR})
+    ecm_install_configured_files(
+      INPUT data/org.buddiesofbudgie.BudgieDaemonV2.service.in DESTINATION
+      ${KDE_INSTALL_SYSTEMDUSERUNITDIR})
+  endif()
+endif()

--- a/src/displays/configuration.hpp
+++ b/src/displays/configuration.hpp
@@ -1,7 +1,7 @@
 #include <optional>
 #include <string>
 
-#include "display.hpp"
+#include "config/display.hpp"
 
 namespace bd::DisplayConfiguration {
   std::optional<DisplayGroupOutputConfig*> getDisplayOutputConfigurationForIdentifier(const QString& identifier, DisplayGroup* group);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,7 +4,7 @@
 #include "config/display.hpp"
 #include "dbus/DisplayService.hpp"
 #include "displays/configuration.hpp"
-#include "output-manager/WaylandOutputManager.hpp"
+#include "displays/output-manager/WaylandOutputManager.hpp"
 
 int main(int argc, char* argv[]) {
   QCoreApplication app(argc, argv);


### PR DESCRIPTION
This completely overhauls the CMake build files, resulting in a cleaner and more readable build system.

One thing to note is that we can't currently use the [KDE compiler settings module](https://api.kde.org/ecm/kde-module/KDECompilerSettings.html) without doing significant work to the entire codebase. I think we should definitely work on enabling it, as it turns on more warnings, and uses stricter settings, which should result in us having a safer codebase.

At the very least, this compiles.